### PR TITLE
✨feat/Main Color typography 페이지 1차 완성

### DIFF
--- a/src/components/main/MainC&T.tsx
+++ b/src/components/main/MainC&T.tsx
@@ -1,0 +1,18 @@
+import { styled } from 'styled-components';
+import MainColorTypographyTitle from './MainC&TTitle';
+import MainColorTypographyItem from './MainC&TItem';
+
+const Container = styled.div`
+  width: 100%;
+`;
+
+function MainColorTypography() {
+  return (
+    <Container>
+      <MainColorTypographyTitle />
+      <MainColorTypographyItem />
+    </Container>
+  );
+}
+
+export default MainColorTypography;

--- a/src/components/main/MainC&TColor.tsx
+++ b/src/components/main/MainC&TColor.tsx
@@ -1,0 +1,106 @@
+import { useState } from 'react';
+import { styled } from 'styled-components';
+import { PALETTE_COMPONENT } from '../../styles/colors';
+
+const Container = styled.div`
+  margin-left: 10.625rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+`;
+
+const Title = styled.div`
+  margin-bottom: 0.625rem;
+  font-size: 1.25rem;
+  font-weight: 900;
+  color: ${PALETTE_COMPONENT.primary_beige};
+`;
+
+const TitleInfo = styled.div`
+  margin-bottom: 2.875rem;
+  font-size: 1.25rem;
+  font-weight: 400;
+  color: ${PALETTE_COMPONENT.gray04};
+`;
+
+const Item = styled.div`
+  display: flex;
+`;
+
+const BlackColor = styled.div<{ hover: boolean }>`
+  padding: 2.5rem;
+  border: 2px solid ${PALETTE_COMPONENT.primary_beige};
+  border-radius: 2.5rem;
+  background-color: ${PALETTE_COMPONENT.primary_black};
+  color: ${(props) =>
+    props.hover
+      ? PALETTE_COMPONENT.primary_beige
+      : PALETTE_COMPONENT.primary_black};
+  transition: all 0.5s 0.5s;
+`;
+
+const BeigeColor = styled.div<{ hover: boolean }>`
+  position: absolute;
+  padding: 2.5rem;
+  margin-left: ${(props) => (props.hover ? '26rem' : '7.5rem')};
+  border: 2px solid ${PALETTE_COMPONENT.primary_beige};
+  border-radius: 2.5rem;
+  background-color: ${PALETTE_COMPONENT.primary_beige};
+  color: ${PALETTE_COMPONENT.primary_black};
+  transition: all 1s;
+`;
+
+const ColorHexText = styled.div`
+  margin-right: 13.125rem;
+  margin-bottom: 24.375rem;
+
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+
+  font-size: 1.25rem;
+  font-weight: 400;
+`;
+
+const ColorExText = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+
+  font-size: 5rem;
+  font-weight: 400;
+`;
+
+function MainColorTypographyColor() {
+  const [hover, setHover] = useState(false);
+
+  const mouseHoverHandler = () => {
+    setHover(true);
+  };
+
+  const mouseLeaveHandler = () => {
+    setHover(false);
+  };
+  return (
+    <Container>
+      <Title>Color pallette</Title>
+      <TitleInfo>This website uses a colorpallette of 2 colors</TitleInfo>
+      <Item>
+        <BlackColor
+          onMouseEnter={mouseHoverHandler}
+          onMouseLeave={mouseLeaveHandler}
+          hover={hover}
+        >
+          <ColorHexText>HEX #171717</ColorHexText>
+          <ColorExText>Aa</ColorExText>
+        </BlackColor>
+        <BeigeColor hover={hover}>
+          <ColorHexText>HEX #FFF8E7</ColorHexText>
+          <ColorExText>Aa</ColorExText>
+        </BeigeColor>
+      </Item>
+    </Container>
+  );
+}
+
+export default MainColorTypographyColor;

--- a/src/components/main/MainC&TItem.tsx
+++ b/src/components/main/MainC&TItem.tsx
@@ -1,0 +1,20 @@
+import { styled } from 'styled-components';
+import MainColorTypographyColor from './MainC&TColor';
+import MainColorTypographyTypography from './MainC&TTypography';
+
+const Container = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+`;
+
+function MainColorTypographyItem() {
+  return (
+    <Container>
+      <MainColorTypographyColor />
+      <MainColorTypographyTypography />
+    </Container>
+  );
+}
+
+export default MainColorTypographyItem;

--- a/src/components/main/MainC&TTitle.tsx
+++ b/src/components/main/MainC&TTitle.tsx
@@ -1,0 +1,20 @@
+import { styled } from 'styled-components';
+import { PALETTE_COMPONENT } from '../../styles/colors';
+
+const Container = styled.div`
+  margin-bottom: 7.5rem;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  font-size: 6.25rem;
+  font-weight: 400;
+  color: ${PALETTE_COMPONENT.primary_beige};
+`;
+
+function MainColorTypographyTitle() {
+  return <Container>COLOR & TYPOGRAPHY</Container>;
+}
+
+export default MainColorTypographyTitle;

--- a/src/components/main/MainC&TTypography.tsx
+++ b/src/components/main/MainC&TTypography.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useState } from 'react';
 import { styled } from 'styled-components';
 import MainColorTypographyTypographyTitle from './MainC&TTypographyTitle';
-import MainColorTypographyTypographyF from './MainC&TTypographyF';
+
 import MainColorTypographyTypographyT from './MainC&TTypographyT';
+import MainColorTypographyTypographyF from './MainC&TTypographyF';
 import MainColorTypographyTypographyL from './MainC&TTypographyL';
 
 const Container = styled.div`

--- a/src/components/main/MainC&TTypography.tsx
+++ b/src/components/main/MainC&TTypography.tsx
@@ -1,0 +1,70 @@
+import { useEffect, useState } from 'react';
+import { styled } from 'styled-components';
+import MainColorTypographyTypographyTitle from './MainC&TTypographyTitle';
+import MainColorTypographyTypographyF from './MainC&TTypographyF';
+import MainColorTypographyTypographyT from './MainC&TTypographyT';
+import MainColorTypographyTypographyL from './MainC&TTypographyL';
+
+const Container = styled.div`
+  width: 680px;
+  margin-right: 4.375rem;
+  display: flex;
+  flex-direction: column;
+`;
+
+const Tap = styled.div`
+  display: flex;
+  justify-content: space-between;
+`;
+
+const Item = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+function MainColorTypographyTypography() {
+  const [selectTitle, setSelectTitle] = useState('TYPOGRAPHY');
+  const [page, setPage] = useState(0);
+
+  const data = [
+    <MainColorTypographyTypographyT />,
+    <MainColorTypographyTypographyF />,
+    <MainColorTypographyTypographyL />,
+  ];
+
+  useEffect(() => {
+    if (selectTitle === 'TYPOGRAPHY') {
+      setPage(0);
+    } else if (selectTitle === 'FONT DETAIL') {
+      setPage(1);
+    } else if (selectTitle === 'LETTERS + NUMBERS') {
+      setPage(2);
+    }
+  }, [selectTitle]);
+
+  return (
+    <Container>
+      <Tap>
+        <MainColorTypographyTypographyTitle
+          value="TYPOGRAPHY"
+          selectTitle={selectTitle}
+          setSelectTitle={setSelectTitle}
+        />
+        <MainColorTypographyTypographyTitle
+          value="FONT DETAIL"
+          selectTitle={selectTitle}
+          setSelectTitle={setSelectTitle}
+        />
+        <MainColorTypographyTypographyTitle
+          value="LETTERS + NUMBERS"
+          selectTitle={selectTitle}
+          setSelectTitle={setSelectTitle}
+        />
+      </Tap>
+      <Item>{data[page]}</Item>
+    </Container>
+  );
+}
+
+export default MainColorTypographyTypography;

--- a/src/components/main/MainC&TTypographyF.tsx
+++ b/src/components/main/MainC&TTypographyF.tsx
@@ -1,0 +1,28 @@
+import { styled } from 'styled-components';
+import { PALETTE_COMPONENT } from '../../styles/colors';
+
+const Container = styled.div`
+  margin-top: 8.25rem;
+
+  font-size: 3.75rem;
+  font-weight: 400;
+  color: ${PALETTE_COMPONENT.primary_beige};
+`;
+
+const NumText = styled.div`
+  font-size: 4.05rem;
+`;
+
+function MainColorTypographyTypographyF() {
+  return (
+    <Container>
+      <div>Aa Bb Cc Dd Ee Ff Gg</div>
+      <div>Hh Ii Jj Kk Ll Mm Nn</div>
+      <div>Oo Pp Qq Rr Ss Tt Uu</div>
+      <div>Vv Ww Xx Yy Zz</div>
+      <NumText>1 2 3 4 5 6 7 8 9 0</NumText>
+    </Container>
+  );
+}
+
+export default MainColorTypographyTypographyF;

--- a/src/components/main/MainC&TTypographyF.tsx
+++ b/src/components/main/MainC&TTypographyF.tsx
@@ -2,27 +2,15 @@ import { styled } from 'styled-components';
 import { PALETTE_COMPONENT } from '../../styles/colors';
 
 const Container = styled.div`
-  margin-top: 8.25rem;
+  margin-top: 14.375rem;
 
-  font-size: 3.75rem;
+  font-size: 12.5rem;
   font-weight: 400;
   color: ${PALETTE_COMPONENT.primary_beige};
 `;
 
-const NumText = styled.div`
-  font-size: 4.05rem;
-`;
-
 function MainColorTypographyTypographyF() {
-  return (
-    <Container>
-      <div>Aa Bb Cc Dd Ee Ff Gg</div>
-      <div>Hh Ii Jj Kk Ll Mm Nn</div>
-      <div>Oo Pp Qq Rr Ss Tt Uu</div>
-      <div>Vv Ww Xx Yy Zz</div>
-      <NumText>1 2 3 4 5 6 7 8 9 0</NumText>
-    </Container>
-  );
+  return <Container>AaBb</Container>;
 }
 
 export default MainColorTypographyTypographyF;

--- a/src/components/main/MainC&TTypographyL.tsx
+++ b/src/components/main/MainC&TTypographyL.tsx
@@ -1,0 +1,16 @@
+import { styled } from 'styled-components';
+import { PALETTE_COMPONENT } from '../../styles/colors';
+
+const Container = styled.div`
+  margin-top: 14.375rem;
+
+  font-size: 12.5rem;
+  font-weight: 400;
+  color: ${PALETTE_COMPONENT.primary_beige};
+`;
+
+function MainColorTypographyTypographyL() {
+  return <Container>AaBb</Container>;
+}
+
+export default MainColorTypographyTypographyL;

--- a/src/components/main/MainC&TTypographyL.tsx
+++ b/src/components/main/MainC&TTypographyL.tsx
@@ -2,15 +2,27 @@ import { styled } from 'styled-components';
 import { PALETTE_COMPONENT } from '../../styles/colors';
 
 const Container = styled.div`
-  margin-top: 14.375rem;
+  margin-top: 8.25rem;
 
-  font-size: 12.5rem;
+  font-size: 3.75rem;
   font-weight: 400;
   color: ${PALETTE_COMPONENT.primary_beige};
 `;
 
+const NumText = styled.div`
+  font-size: 4.05rem;
+`;
+
 function MainColorTypographyTypographyL() {
-  return <Container>AaBb</Container>;
+  return (
+    <Container>
+      <div>Aa Bb Cc Dd Ee Ff Gg</div>
+      <div>Hh Ii Jj Kk Ll Mm Nn</div>
+      <div>Oo Pp Qq Rr Ss Tt Uu</div>
+      <div>Vv Ww Xx Yy Zz</div>
+      <NumText>1 2 3 4 5 6 7 8 9 0</NumText>
+    </Container>
+  );
 }
 
 export default MainColorTypographyTypographyL;

--- a/src/components/main/MainC&TTypographyT.tsx
+++ b/src/components/main/MainC&TTypographyT.tsx
@@ -1,0 +1,16 @@
+import { styled } from 'styled-components';
+import { PALETTE_COMPONENT } from '../../styles/colors';
+
+const Container = styled.div`
+  margin-top: 17.75rem;
+
+  font-size: 5rem;
+  font-weight: 400;
+  color: ${PALETTE_COMPONENT.primary_beige};
+`;
+
+function MainColorTypographyTypographyT() {
+  return <Container>PP Radio Grotesk</Container>;
+}
+
+export default MainColorTypographyTypographyT;

--- a/src/components/main/MainC&TTypographyTitle.tsx
+++ b/src/components/main/MainC&TTypographyTitle.tsx
@@ -1,0 +1,46 @@
+import { useEffect, useState } from 'react';
+import { styled } from 'styled-components';
+import { PALETTE_COMPONENT } from '../../styles/colors';
+
+interface IMainColorTypographyTypographyTitleProps {
+  value: string;
+  selectTitle: string;
+  setSelectTitle: (a: string) => void;
+}
+
+const Container = styled.div<{ isSelect: boolean }>`
+  font-size: 1.25rem;
+  font-weight: ${(props) => (props.isSelect ? 900 : 400)};
+  color: ${(props) =>
+    props.isSelect
+      ? PALETTE_COMPONENT.primary_beige
+      : PALETTE_COMPONENT.gray04};
+`;
+
+function MainColorTypographyTypographyTitle({
+  value,
+  selectTitle,
+  setSelectTitle,
+}: IMainColorTypographyTypographyTitleProps) {
+  const [isSelect, setIsSelect] = useState(false);
+
+  useEffect(() => {
+    if (value === selectTitle) {
+      setIsSelect(true);
+    } else {
+      setIsSelect(false);
+    }
+  }, [value, selectTitle]);
+
+  const titleClickHandler = () => {
+    setSelectTitle(value);
+  };
+
+  return (
+    <Container onClick={titleClickHandler} isSelect={isSelect}>
+      {value}
+    </Container>
+  );
+}
+
+export default MainColorTypographyTypographyTitle;


### PR DESCRIPTION
## 제목

### 🛠️ What does this PR do?
- [x] Main페이지의  Color & typography 페이지 완성했습니다.
- [x] Color의 검은 색상부분에 hover시 밝은 부분이 오른쪽으로 이동하도록 하는 이벤트 로직 완성했습니다.
- [x] Typography의 tab의 제목에 맞춰 내용이 바뀌도록 하는 이벤트 로직 완성 했습니다.

### 🔍 Why are we doing this?
.

### 📸 ScreenShots
- All
![image](https://github.com/sienna0715/foorloop/assets/115691844/d77a2723-52c3-4560-aaf3-adae20231e90)

- Color
![image](https://github.com/sienna0715/foorloop/assets/115691844/0bf83ad0-42ac-4fba-9592-dff117c425b5)
![image](https://github.com/sienna0715/foorloop/assets/115691844/82df1322-24b8-4911-846e-577e4fe2b6fc)

- Typography
![image](https://github.com/sienna0715/foorloop/assets/115691844/2c4e3ed1-f502-42c0-a975-786fbfa5bc7e)
![image](https://github.com/sienna0715/foorloop/assets/115691844/e34ce5af-3d95-4e19-bed5-2c31d699bdf2)
![image](https://github.com/sienna0715/foorloop/assets/115691844/041761f5-0109-4ed8-a01d-f11c139dd690)

